### PR TITLE
chore: Change JWT storage from cookie to localStorage

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1,53 +1,14 @@
 import axios, { AxiosInstance, InternalAxiosRequestConfig } from 'axios';
 
-/**
- * getAuthToken - Retrieves the authentication token from localStorage
- *
- * @returns {string|null} The authentication token or null if not found
- */
-const getAuthToken = (): string | null => {
-  // Check localStorage for token
-  const localStorageToken = localStorage.getItem('authToken');
-
-  if (localStorageToken) {
-    return localStorageToken;
-  }
-
-  // As a fallback, try common cookie names
-  try {
-    const cookies = document.cookie.split(';');
-    const possibleNames = [
-      'jwt',
-      'token',
-      'auth',
-      'authorization',
-      'accessToken',
-      'access_token',
-      'authToken',
-      'auth_token'
-    ];
-
-    for (const cookie of cookies) {
-      const [name, value] = cookie.trim().split('=');
-      if (possibleNames.includes(name.toLowerCase())) {
-        return value;
-      }
-    }
-  } catch (e) {
-    // Silently fail and return null
-  }
-
-  return null;
-};
+import { tokenStorage } from './utils/tokenStorage';
 
 /**
  * Adds the Authorization header to the request configuration
  */
 const addAuthHeader = (config: InternalAxiosRequestConfig): InternalAxiosRequestConfig => {
-  const token = getAuthToken();
+  const token = tokenStorage.getToken();
 
   if (token) {
-    // Set the Authorization header directly
     config.headers.Authorization = `Bearer ${token}`;
   }
 
@@ -57,7 +18,6 @@ const addAuthHeader = (config: InternalAxiosRequestConfig): InternalAxiosRequest
 // Create the API for movies with specific configuration
 export const api: AxiosInstance = axios.create({
   baseURL: process.env.BASE_URL_API,
-  withCredentials: true, // Still include cookies in case they're used
   headers: {
     'Content-Type': 'application/json'
   }
@@ -81,41 +41,12 @@ api.interceptors.response.use(
 // Auth API instance
 export const authApi: AxiosInstance = axios.create({
   baseURL: process.env.BASE_URL_AUTH,
-  withCredentials: true,
   headers: {
     'Content-Type': 'application/json'
   }
 });
 
-// Add response interceptor to extract and save token from auth API responses
-authApi.interceptors.response.use(
-  (response) => {
-    try {
-      // Try response.data.data.token format
-      if (response.data?.data?.token) {
-        const token = response.data.data.token;
-        localStorage.setItem('authToken', token);
-      }
-      // Try response.data.token format
-      else if (response.data?.token) {
-        const token = response.data.token;
-        localStorage.setItem('authToken', token);
-      }
-      // Check headers for token
-      else if (response.headers.authorization || response.headers.Authorization) {
-        const authHeader = response.headers.authorization || response.headers.Authorization;
-        if (typeof authHeader === 'string') {
-          const token = authHeader.replace('Bearer ', '');
-          localStorage.setItem('authToken', token);
-        }
-      }
-    } catch (e) {
-      // Silently fail
-    }
-
-    return response;
-  },
-  (error) => {
-    return Promise.reject(error);
-  }
-);
+// Add request interceptor to add auth header to auth API requests
+authApi.interceptors.request.use(addAuthHeader, (error) => {
+  return Promise.reject(error);
+});

--- a/src/common/components/Navbar/Navbar.tsx
+++ b/src/common/components/Navbar/Navbar.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router';
 
 import { authApi } from '../../../api';
 import { useUser } from '../../../context/UserContext/UserContext';
+import { tokenStorage } from '../../../utils/tokenStorage';
 
 const Navbar = () => {
   const navigate = useNavigate();
@@ -10,6 +11,7 @@ const Navbar = () => {
 
   const handleLogout = async () => {
     await authApi.delete('/v1/users/logout');
+    tokenStorage.removeToken();
     setUser(null);
     navigate('/login');
   };

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -4,9 +4,10 @@ import { Navigate, useNavigate } from 'react-router';
 import { authApi } from '../../api';
 import LoadingSpinner from '../../common/components/LoadingSpinner/LoadingSpinner';
 import { useUser } from '../../context/UserContext/UserContext';
+import { tokenStorage } from '../../utils/tokenStorage';
 
 /**
- * Login page. User can login with email and password. This sets the user in the UserContext and a JWT token on a cookie.
+ * Login page. User can login with email and password. This sets the user in the UserContext and a JWT token in localStorage.
  * Redirects to the main page after successful login, or stays on the login page if the login fails.
  * If the user is already logged in, redirects to the main page.
  *
@@ -45,15 +46,14 @@ const Login = () => {
 
       if (response.status === 200) {
         // Explicitly check for token in response
-        if (response.data?.data?.token) {
-          const token = response.data.data.token;
-          localStorage.setItem('authToken', token);
+        if (response.data?.token) {
+          tokenStorage.setToken(response.data.token);
         } else {
           // Check headers (case insensitive)
           const authHeader = response.headers.authorization || response.headers.Authorization;
           if (authHeader) {
             const token = typeof authHeader === 'string' ? authHeader.replace('Bearer ', '') : '';
-            localStorage.setItem('authToken', token);
+            tokenStorage.setToken(token);
           }
         }
 

--- a/src/utils/tokenStorage.ts
+++ b/src/utils/tokenStorage.ts
@@ -1,0 +1,19 @@
+const TOKEN_KEY = 'filmotheque_session';
+
+export const tokenStorage = {
+  setToken: (token: string): void => {
+    localStorage.setItem(TOKEN_KEY, token);
+  },
+
+  getToken: (): string | null => {
+    return localStorage.getItem(TOKEN_KEY);
+  },
+
+  removeToken: (): void => {
+    localStorage.removeItem(TOKEN_KEY);
+  },
+
+  hasToken: (): boolean => {
+    return localStorage.getItem(TOKEN_KEY) !== null;
+  }
+};


### PR DESCRIPTION
### What's new

- Now the JWT auth token instead of being stored on a cookie it's stored on localStorage.

### What's fixed

Nothing fixed here...

### How to test

- `yarn test`
- Start it and try to login

### Breaking changes

- JWT is now stored on localStorage instead of cookie

### Checklist

- [x] I've tested locally the changes
- [x] I've run `yarn verify` to perform basic checks and lints
- [x] I've run `gitleaks` to check for hardcoded secrets and tokens
